### PR TITLE
Public frames

### DIFF
--- a/common/mixins/isPublicOrOwner.js
+++ b/common/mixins/isPublicOrOwner.js
@@ -58,13 +58,15 @@ module.exports = function(Model, options) {
         let userId = ctx.req.accessToken && ctx.req.accessToken.userId;
 
         // if result is true, we want to reject this item
-        function allowResult(work) {
-            return (work.is_public || work.ownerId.toString() === userId.toString());
+        function allowResult(model) {
+            debug('model', model.is_public, model.ownerId, userId);
+            return (model.is_public || (userId && model.ownerId && model.ownerId.toString() === userId.toString()));
         }
 
         if (ctx.result) {
             let newResult;
             if (Array.isArray(resultInstance)) {
+                debug('isArray', resultInstance.length);
                 newResult = [];
                 ctx.result.forEach(function(result) {
                     if (allowResult(result)) {

--- a/common/mixins/isPublicOrOwner.js
+++ b/common/mixins/isPublicOrOwner.js
@@ -59,7 +59,7 @@ module.exports = function(Model, options) {
 
         // if result is true, we want to reject this item
         function allowResult(model) {
-            debug('model', model.is_public, model.ownerId, userId);
+            // debug('model', model.is_public, model.ownerId, userId);
             return (model.is_public || (userId && model.ownerId && model.ownerId.toString() === userId.toString()));
         }
 

--- a/common/models/frame.json
+++ b/common/models/frame.json
@@ -7,7 +7,8 @@
     "validateUpsert": true
   },
   "mixins": {
-    "Timestamp": {}
+    "Timestamp": {},
+    "IsPublicOrOwner": {}
   },
   "scope": {
     "order": "created",
@@ -35,6 +36,11 @@
       "type": "object",
       "required": true,
       "default": {}
+    },
+    "is_public": {
+      "type": "boolean",
+      "required": true,
+      "default": false
     },
     "extensions": {
       "type": "object",
@@ -79,7 +85,7 @@
     {
       "accessType": "READ",
       "principalType": "ROLE",
-      "principalId": "$authenticated",
+      "principalId": "$everyone",
       "permission": "ALLOW"
     },
     {


### PR DESCRIPTION
Like Artworks, add `is_public` flag to allow Frames to be publicly viewable.

Also fixes bug with `IsPublicOrOwner` mixin check where userId may be undefined.